### PR TITLE
"Package.json: Fix `license` to include fonts"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "Apache-2.0",
+  "license": "(Apache-2.0 AND (Apache-2.0 OR OFL-1.1 OR GPL-2.0-only WITH Font exception 2.0))", 
   "dependencies": {},
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
   Updated `license` to reflect Apache-2.0 is the license for the code
   and each fonts comes with its own license either Apache-2.0,
   OFL-1.1 or GPL-2.0-only WITH Font exception 2.0.

Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>