### PR TITLE
Minor: Clean-up font generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ doc
 *.js
 *.js.map
 resources
+test/resources
 output

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.1",
   "description": "Font resources for harp.gl",
   "scripts": {
-    "test": "cross-env ts-mocha $EXTRA_MOCHA_ARGS ./test/*.ts",
+    "test": "ts-node ./scripts/create-font-catalog.ts -i ./resources-dev/TestFonts.json -o ./test/resources && cross-env ts-mocha $EXTRA_MOCHA_ARGS ./test/*.ts",
+    "create-font-catalog": "ts-node ./scripts/create-font-catalog.ts",
     "prepack": "ts-node ./scripts/create-font-catalog.ts -i ./resources-dev/DefaultFonts.json -o ./resources"
   },
   "repository": {
@@ -17,7 +18,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "(Apache-2.0 AND (Apache-2.0 OR OFL-1.1 OR GPL-2.0-only WITH Font exception 2.0))", 
+  "license": "(Apache-2.0 AND (Apache-2.0 OR OFL-1.1 OR GPL-2.0-only WITH Font exception 2.0))",
   "dependencies": {},
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/resources-dev/TestFonts.json
+++ b/resources-dev/TestFonts.json
@@ -1,0 +1,15 @@
+{
+    "name": "Test",
+    "size": 32,
+    "distance": 8,
+    "type": "msdf",
+    "fontsDir": "../Fonts",
+    "fonts": [
+        {
+            "name": "FiraGO_Map",
+            "blocks": [
+                "Basic Latin"
+            ]
+        }
+    ]
+}

--- a/scripts/create-font-catalog.ts
+++ b/scripts/create-font-catalog.ts
@@ -1,6 +1,6 @@
 /**
  * Script designed to generate the TextCanvas' FontCatalog assets.
- * Usage: npm run create-font-catalog -- -n <name> -f <file> -s <size> -t <type> -d <distance>
+ * Usage: yarn create-font-catalog -- -i <inputFile> -o <outputDir>
  */
 
 // tslint:disable

--- a/test/FontCatalogTest.ts
+++ b/test/FontCatalogTest.ts
@@ -1,0 +1,13 @@
+import { assert } from "chai";
+
+// tslint:disable
+const fs = require("fs");
+const path = require("path");
+// tslint:enable
+
+describe("FontCatalog", function() {
+    it("Creation", function() {
+        const fontCatalogPath = path.resolve(__dirname, "./resources/Test_FontCatalog.json");
+        assert.isTrue(fs.existsSync(fontCatalogPath));
+    });
+});

--- a/test/FontCatalogText.ts
+++ b/test/FontCatalogText.ts
@@ -1,7 +1,0 @@
-import { assert } from "chai";
-
-describe("FontCatalog", function() {
-    it("dummy", function() {
-        assert.strictEqual(1, 1);
-    });
-});


### PR DESCRIPTION
* Exposed ``create-font-catalog`` in npm package.json.
* Updated the documentation on how to use ``create-font-catalog``.
* Replaced ``FontCatalogText.ts`` for more useful script that checks if basic FontCatalog generation works.