### PR TITLE
package.json: Fix invalid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "(Apache-2.0 AND (Apache-2.0 OR OFL-1.1 OR GPL-2.0-only WITH Font exception 2.0))",
+  "license": "(Apache-2.0 AND (Apache-2.0 OR OFL-1.1 OR GPL-2.0-only WITH Font-exception-2.0))",
   "dependencies": {},
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
`yarn check` showed that license was a invalid SPDX license expression

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>